### PR TITLE
Simplify smallest_multiple_of_n_geq_m

### DIFF
--- a/prime_sieve/math_utils.py
+++ b/prime_sieve/math_utils.py
@@ -6,4 +6,4 @@ def smallest_multiple_of_n_geq_m(n: int, m: int) -> int:
     :param m: A non-negative integer.
     :return: The smallest multiple of n that is greater or equal to m.
     """
-    return m + ((n - (m % n)) % n)
+    return m + -m % n


### PR DESCRIPTION
Small change to simplify and somewhat optimize `smallest_multiple_of_n_geq_m`.
```python
In [1]: def smallest_multiple_of_n_geq_m(n: int, m: int) -> int:
   ...:     return m + -m % n
In [2]: %timeit [smallest_multiple_of_n_geq_m(17, i) for i in range(10**6)]
237 ms ± 2.47 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [3]: 
   ...: def smallest_multiple_of_n_geq_m(n: int, m: int) -> int:
   ...:     return m + ((n - (m % n)) % n)
In [4]: %timeit [smallest_multiple_of_n_geq_m(17, i) for i in range(10**6)]
261 ms ± 7.56 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```